### PR TITLE
Release/v0.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,17 +33,6 @@ custom:
 
 It's done! Now when you run `serverless deploy`, this plugin executes `AssumeRole` action before the deployment and then deploys your package with the IAM Role.
 
-## Available commands
-
-At the time of wrinting, this plugin runs before the execution of these commands.
-
-- serverless deploy
-- serverless deploy list
-- serverless info
-- serverless remove
-- serverless logs
-- serverless invoke
-
 ## License
 
 This software is released under the [MIT License](LICENSE).

--- a/example/package.json
+++ b/example/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
     "prestart": "cd .. && npm run build",
-    "start": "npx sls assumerole:test"
+    "start": "npx sls print --verbose"
   },
   "devDependencies": {
     "serverless": "^3.25.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "serverless-assume-role",
-  "version": "1.0.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "serverless-assume-role",
-      "version": "1.0.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "aws-sdk": "^2.1267.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-assume-role",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "A Serverless framework plugin to enable AWS assume role",
   "main": "dist/index.js",
   "scripts": {

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -2,8 +2,7 @@ import AWS from 'aws-sdk'
 import ServerlessAssumeRole, {
   Serverless,
   Options,
-  Utils,
-  AwsProvider
+  Utils
 } from '..'
 
 jest.mock('aws-sdk')

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -194,18 +194,9 @@ describe('ServerlessAssumeRole', () => {
       expect(() => subject({ transitiveTagKeys: {} })).toThrow(error)
     })
 
-    const events: string [] = [
-      'deploy:deploy',
-      'deploy:list:log',
-      'info:info',
-      'remove:remove',
-      'logs:logs',
-      'invoke:invoke'
-    ]
-
-    it.each(events)('sets hook to "before:%s" event', (event) => {
+    it('sets hook to "initialize" event', () => {
       const plugin = subject({})
-      expect(plugin.hooks[`before:${event}`]).toBeDefined()
+      expect(plugin.hooks.initialize).toBeDefined()
     })
   })
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -86,15 +86,9 @@ export default class ServerlessAssumeRole {
       }
     }
 
-    // Ref: https://gist.github.com/HyperBrain/50d38027a8f57778d5b0f135d80ea406
     this.hooks = {
       'assumerole:test:run': this.run.bind(this),
-      'before:deploy:deploy': this.run.bind(this),
-      'before:deploy:list:log': this.run.bind(this),
-      'before:info:info': this.run.bind(this),
-      'before:remove:remove': this.run.bind(this),
-      'before:logs:logs': this.run.bind(this),
-      'before:invoke:invoke': this.run.bind(this)
+      initialize: this.run.bind(this)
     }
   }
 


### PR DESCRIPTION
# v0.1.1

## Improvements

- bugfix for using aws variables

If there are `aws:accountId` or `aws:region` in serverless.yml, these variables are resolved before any plugin actions. So I changed assume role trigger to invoke before the resolving process.